### PR TITLE
Const Correctness and Bug Fixes

### DIFF
--- a/include/libdbc/dbc.hpp
+++ b/include/libdbc/dbc.hpp
@@ -27,18 +27,18 @@ public:
 	void parse_file(const std::string& file_name) override;
 	void parse_file(std::istream& stream) override;
 
-	std::string get_version() const;
-	std::vector<std::string> get_nodes() const;
-	std::vector<Libdbc::Message> get_messages() const;
+	const std::string& get_version() const;
+	const std::vector<std::string>& get_nodes() const;
+	const std::vector<Libdbc::Message>& get_messages() const;
 
 	Message::ParseSignalsStatus parse_message(uint32_t message_id, const std::vector<uint8_t>& data, std::vector<double>& out_values);
 
-	std::vector<std::string> unused_lines() const;
+	const std::vector<std::string>& unused_lines() const;
 
 private:
-	std::string version;
-	std::vector<std::string> nodes;
-	std::vector<Libdbc::Message> messages;
+	std::string version{};
+	std::vector<std::string> nodes{};
+	std::vector<Libdbc::Message> messages{};
 
 	std::regex version_re;
 	std::regex bit_timing_re;
@@ -48,7 +48,7 @@ private:
 	std::regex value_re;
 	std::regex signal_re;
 
-	std::vector<std::string> missed_lines;
+	std::vector<std::string> missed_lines{};
 
 	void parse_dbc_header(std::istream& file_stream);
 	void parse_dbc_nodes(std::istream& file_stream);

--- a/include/libdbc/dbc.hpp
+++ b/include/libdbc/dbc.hpp
@@ -31,7 +31,7 @@ public:
 	const std::vector<std::string>& get_nodes() const;
 	const std::vector<Libdbc::Message>& get_messages() const;
 
-	Message::ParseSignalsStatus parse_message(uint32_t message_id, const std::vector<uint8_t>& data, std::vector<double>& out_values);
+	Message::ParseSignalsStatus parse_message(uint32_t message_id, const std::vector<uint8_t>& data, std::vector<double>& out_values) const;
 
 	const std::vector<std::string>& unused_lines() const;
 

--- a/include/libdbc/dbc.hpp
+++ b/include/libdbc/dbc.hpp
@@ -8,6 +8,10 @@
 #include <string>
 #include <vector>
 
+#if __cplusplus >= 201703L
+	#include <filesystem>
+#endif // __cplusplus >= 201703L
+
 namespace Libdbc {
 
 class Parser {
@@ -34,6 +38,13 @@ public:
 	Message::ParseSignalsStatus parse_message(uint32_t message_id, const std::vector<uint8_t>& data, std::vector<double>& out_values) const;
 
 	const std::vector<std::string>& unused_lines() const;
+
+	#if __cplusplus >= 201703L
+	static bool is_valid_dbc_file(const std::filesystem::path&);
+	#else
+	static bool is_valid_dbc_file(const std::string&);
+	#endif // __cplusplus >= 201703L
+	static bool is_valid_dbc_file(std::istream& stream);
 
 private:
 	std::string version{};

--- a/include/libdbc/message.hpp
+++ b/include/libdbc/message.hpp
@@ -19,6 +19,7 @@ struct Message {
 		ErrorBigEndian,
 		ErrorUnknownID,
 		ErrorInvalidConversion,
+		ErrorInvalidSignalSize,
 	};
 
 	ParseSignalsStatus parse_signals(const std::vector<uint8_t>& data, std::vector<double>& values) const;

--- a/include/libdbc/message.hpp
+++ b/include/libdbc/message.hpp
@@ -24,7 +24,7 @@ struct Message {
 	ParseSignalsStatus parse_signals(const std::vector<uint8_t>& data, std::vector<double>& values) const;
 
 	void append_signal(const Signal& signal);
-	std::vector<Signal> get_signals() const;
+	const std::vector<Signal>& get_signals() const;
 	uint32_t id() const;
 	uint8_t size() const;
 	const std::string& name() const;
@@ -33,11 +33,11 @@ struct Message {
 	virtual bool operator==(const Message& rhs) const;
 
 private:
-	uint32_t m_id;
-	std::string m_name;
-	uint8_t m_size;
-	std::string m_node;
-	std::vector<Signal> m_signals;
+	uint32_t m_id{};
+	std::string m_name{};
+	uint8_t m_size{};
+	std::string m_node{};
+	std::vector<Signal> m_signals{};
 
 	friend std::ostream& operator<<(std::ostream& out, const Message& msg);
 };

--- a/include/libdbc/signal.hpp
+++ b/include/libdbc/signal.hpp
@@ -30,7 +30,7 @@ struct Signal {
 
 	Signal() = delete;
 	virtual ~Signal() = default;
-	explicit Signal(std::string name,
+	explicit Signal(const std::string& name,
 					bool is_multiplexed,
 					uint32_t start_bit,
 					uint32_t size,
@@ -40,8 +40,8 @@ struct Signal {
 					double offset,
 					double min,
 					double max,
-					std::string unit,
-					std::vector<std::string> receivers);
+					const std::string& unit,
+					const std::vector<std::string>& receivers);
 
 	virtual bool operator==(const Signal& rhs) const;
 	bool operator<(const Signal& rhs) const;

--- a/include/libdbc/utils/utils.hpp
+++ b/include/libdbc/utils/utils.hpp
@@ -63,7 +63,7 @@ std::string		trim(const T& value) {
 constexpr auto  trim(const T& value, std::initializer_list<char>& trimChars) {
 #else
 template<typename T>
-std::string  	trim(const T& value, std::initializer_list<char>& trimChars) {
+std::string  	trim(const T& value, const std::initializer_list<char>& trimChars) {
 #endif // __cplusplus >= 201703
 	T trimmedValue = value;
 	trimmedValue.erase(trimmedValue.begin(), std::find_if(trimmedValue.begin(), trimmedValue.end(), [&trimChars](int ch) { return std::find(trimChars.begin(), trimChars.end(), static_cast<char>(ch)) == trimChars.end(); }));
@@ -79,6 +79,21 @@ std::string  	trim(const T& value, std::initializer_list<char>& trimChars) {
 #	endif // __cpp_concepts >= 201907
 constexpr auto  trim(const T& value, const std::string_view& trimChars) { return trim(value, std::initializer_list<char>(trimChars.begin(), trimChars.end())); }
 #endif // __cplusplus >= 201703L
+
+/**
+ * @brief Checks if the given string is empty or contains only whitespace characters.
+ * 
+ * @tparam T The typeparam; must be stringable.
+ * 
+ * @param str The string to check against.
+ * 
+ * @return true If the string is empty or consists only of whitespace.
+ * @return false Otherwise.
+ */
+template<typename T>
+constexpr bool  isWhitespaceOrEmpty(const T& str) {
+	return std::all_of(str.begin(), str.end(), [](char c) { return std::isspace(c); });
+}
 
 class String {
 public:

--- a/include/libdbc/utils/utils.hpp
+++ b/include/libdbc/utils/utils.hpp
@@ -2,6 +2,7 @@
 #ifndef UTILS_HPP
 #define UTILS_HPP
 
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -9,6 +10,12 @@
 #if __cplusplus >= 201703L
 #	include <string_view>
 #endif // __cplusplus >= 201703L
+
+#if __cpp_concepts >= 201907
+#include <concepts>
+template<typename Str>
+concept procsys_stringable = requires(Str s) { { s.data() + s.size() } -> std::convertible_to<const char*>; };
+#endif // __cpp_concepts >= 201907
 
 namespace Utils {
 
@@ -31,7 +38,11 @@ public:
 };
 
 #if __cplusplus >= 201703
-template<typename T>
+#	if __cpp_concepts >= 201907
+	template<procsys_stringable T>
+#	else
+	template<typename T>
+#	endif // __cpp_concepts >= 201907
 constexpr auto  trim(const T& value) {
 #else
 template<typename T>
@@ -43,18 +54,12 @@ std::string		trim(const T& value) {
 	return trimmedValue;
 }
 
-#if __cplusplus >= 201703L
-template<typename T>
-constexpr auto  trim(const T& value, const std::string_view& trimChars) {
-	T trimmedValue = value;
-	trimmedValue.erase(trimmedValue.begin(), std::find_if(trimmedValue.begin(), trimmedValue.end(), [&trimChars](int ch) { return trimChars.find(static_cast<char>(ch)) == std::string_view::npos; }));
-	trimmedValue.erase(std::find_if(trimmedValue.rbegin(), trimmedValue.rend(), [&trimChars](int ch) { return trimChars.find(static_cast<char>(ch)) == std::string_view::npos; }).base(), trimmedValue.end());
-	return trimmedValue;
-}
-#endif // __cplusplus >= 201703L
-
 #if __cplusplus >= 201703
-template<typename T>
+#	if __cpp_concepts >= 201907
+	template<procsys_stringable T>
+#	else
+	template<typename T>
+#	endif // __cpp_concepts >= 201907
 constexpr auto  trim(const T& value, std::initializer_list<char>& trimChars) {
 #else
 template<typename T>
@@ -65,6 +70,15 @@ std::string  	trim(const T& value, std::initializer_list<char>& trimChars) {
 	trimmedValue.erase(std::find_if(trimmedValue.rbegin(), trimmedValue.rend(), [&trimChars](int ch) { return std::find(trimChars.begin(), trimChars.end(), static_cast<char>(ch)) == trimChars.end(); }).base(), trimmedValue.end());
 	return trimmedValue;
 }
+
+#if __cplusplus >= 201703L
+#	if __cpp_concepts >= 201907
+	template<procsys_stringable T>
+#	else
+	template<typename T>
+#	endif // __cpp_concepts >= 201907
+constexpr auto  trim(const T& value, const std::string_view& trimChars) { return trim(value, std::initializer_list<char>(trimChars.begin(), trimChars.end())); }
+#endif // __cplusplus >= 201703L
 
 class String {
 public:

--- a/include/libdbc/utils/utils.hpp
+++ b/include/libdbc/utils/utils.hpp
@@ -37,6 +37,15 @@ public:
 	static std::istream& skip_to_next_blank_line(std::istream& stream, std::string& line);
 };
 
+/**
+ * @brief Trims the specified characters from the beginning and end of the given string.
+ * 
+ * @tparam T The typeparam; must be stringable.
+ * @param value The string to trim.
+ * @return A new string with the specified characters trimmed.
+ * 
+ * @copyright 2025 Procyon Systems Inh. Simon Cahill (s.cahill@procyon-systems.de)
+ */
 #if __cplusplus >= 201703
 #	if __cpp_concepts >= 201907
 	template<procsys_stringable T>
@@ -54,6 +63,16 @@ std::string		trim(const T& value) {
 	return trimmedValue;
 }
 
+/**
+ * @brief Trims the specified characters from the beginning and end of the given string.
+ * 
+ * @tparam T The typeparam; must be stringable.
+ * @param value The string to trim.
+ * @param trimChars The characters to trim from the string.
+ * @return A new string with the specified characters trimmed.
+ * 
+ * @copyright 2025 Procyon Systems Inh. Simon Cahill (s.cahill@procyon-systems.de)
+ */
 #if __cplusplus >= 201703
 #	if __cpp_concepts >= 201907
 	template<procsys_stringable T>
@@ -71,6 +90,16 @@ std::string  	trim(const T& value, const std::initializer_list<char>& trimChars)
 	return trimmedValue;
 }
 
+/**
+ * @brief Trims the specified characters from the beginning and end of the given string.
+ * 
+ * @tparam T The typeparam; must be stringable.
+ * @param value The string to trim.
+ * @param trimChars The characters to trim from the string.
+ * @return A new string with the specified characters trimmed.
+ * 
+ * @copyright 2025 Procyon Systems Inh. Simon Cahill (s.cahill@procyon-systems.de)
+ */
 #if __cplusplus >= 201703L
 #	if __cpp_concepts >= 201907
 	template<procsys_stringable T>
@@ -89,6 +118,8 @@ constexpr auto  trim(const T& value, const std::string_view& trimChars) { return
  * 
  * @return true If the string is empty or consists only of whitespace.
  * @return false Otherwise.
+ * 
+ * @copyright 2025 Procyon Systems Inh. Simon Cahill (s.cahill@procyon-systems.de)
  */
 template<typename T>
 constexpr bool  isWhitespaceOrEmpty(const T& str) {

--- a/include/libdbc/utils/utils.hpp
+++ b/include/libdbc/utils/utils.hpp
@@ -6,6 +6,10 @@
 #include <sstream>
 #include <string>
 
+#if __cplusplus >= 201703L
+#	include <string_view>
+#endif // __cplusplus >= 201703L
+
 namespace Utils {
 
 class StreamHandler {
@@ -26,9 +30,45 @@ public:
 	static std::istream& skip_to_next_blank_line(std::istream& stream, std::string& line);
 };
 
+#if __cplusplus >= 201703
+template<typename T>
+constexpr auto  trim(const T& value) {
+#else
+template<typename T>
+std::string		trim(const T& value) {
+#endif // #if __cplusplus >= 201703
+	T trimmedValue = value;
+	trimmedValue.erase(trimmedValue.begin(), std::find_if(trimmedValue.begin(), trimmedValue.end(), [](int ch) { return !std::isspace(ch); }));
+	trimmedValue.erase(std::find_if(trimmedValue.rbegin(), trimmedValue.rend(), [](int ch) { return !std::isspace(ch); }).base(), trimmedValue.end());
+	return trimmedValue;
+}
+
+#if __cplusplus >= 201703L
+template<typename T>
+constexpr auto  trim(const T& value, const std::string_view& trimChars) {
+	T trimmedValue = value;
+	trimmedValue.erase(trimmedValue.begin(), std::find_if(trimmedValue.begin(), trimmedValue.end(), [&trimChars](int ch) { return trimChars.find(static_cast<char>(ch)) == std::string_view::npos; }));
+	trimmedValue.erase(std::find_if(trimmedValue.rbegin(), trimmedValue.rend(), [&trimChars](int ch) { return trimChars.find(static_cast<char>(ch)) == std::string_view::npos; }).base(), trimmedValue.end());
+	return trimmedValue;
+}
+#endif // __cplusplus >= 201703L
+
+#if __cplusplus >= 201703
+template<typename T>
+constexpr auto  trim(const T& value, std::initializer_list<char>& trimChars) {
+#else
+template<typename T>
+std::string  	trim(const T& value, std::initializer_list<char>& trimChars) {
+#endif // __cplusplus >= 201703
+	T trimmedValue = value;
+	trimmedValue.erase(trimmedValue.begin(), std::find_if(trimmedValue.begin(), trimmedValue.end(), [&trimChars](int ch) { return std::find(trimChars.begin(), trimChars.end(), static_cast<char>(ch)) == trimChars.end(); }));
+	trimmedValue.erase(std::find_if(trimmedValue.rbegin(), trimmedValue.rend(), [&trimChars](int ch) { return std::find(trimChars.begin(), trimChars.end(), static_cast<char>(ch)) == trimChars.end(); }).base(), trimmedValue.end());
+	return trimmedValue;
+}
+
 class String {
 public:
-	static std::string trim(const std::string& line);
+	static std::string trim(const std::string& line) { return Utils::trim(line); }
 
 	template<class Container>
 	static void split(const std::string& str, Container& cont, char delim = ' ') {

--- a/src/dbc.cpp
+++ b/src/dbc.cpp
@@ -107,15 +107,15 @@ std::string DbcParser::get_extension(const std::string& file_name) {
 	return "";
 }
 
-std::string DbcParser::get_version() const {
+const std::string& DbcParser::get_version() const {
 	return version;
 }
 
-std::vector<std::string> DbcParser::get_nodes() const {
+const std::vector<std::string>& DbcParser::get_nodes() const {
 	return nodes;
 }
 
-std::vector<Libdbc::Message> DbcParser::get_messages() const {
+const std::vector<Libdbc::Message>& DbcParser::get_messages() const {
 	return messages;
 }
 
@@ -246,7 +246,7 @@ void DbcParser::parse_dbc_messages(const std::vector<std::string>& lines) {
 	}
 }
 
-std::vector<std::string> DbcParser::unused_lines() const {
+const std::vector<std::string>& DbcParser::unused_lines() const {
 	return missed_lines;
 }
 

--- a/src/dbc.cpp
+++ b/src/dbc.cpp
@@ -93,7 +93,7 @@ void DbcParser::parse_file(const std::string& file_name) {
 		throw NonDbcFileFormatError(file_name, extension);
 	}
 
-	std::ifstream stream(file_name.c_str());
+	std::ifstream stream(file_name);
 
 	parse_file(stream);
 }

--- a/src/dbc.cpp
+++ b/src/dbc.cpp
@@ -119,7 +119,7 @@ const std::vector<Libdbc::Message>& DbcParser::get_messages() const {
 	return messages;
 }
 
-Message::ParseSignalsStatus DbcParser::parse_message(const uint32_t message_id, const std::vector<uint8_t>& data, std::vector<double>& out_values) {
+Message::ParseSignalsStatus DbcParser::parse_message(const uint32_t message_id, const std::vector<uint8_t>& data, std::vector<double>& out_values) const {
 	for (const auto& message : messages) {
 		if (message.id() == message_id) {
 			return message.parse_signals(data, out_values);

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -1,3 +1,5 @@
+#include <arpa/inet.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <libdbc/message.hpp>
@@ -35,15 +37,20 @@ Message::ParseSignalsStatus Message::parse_signals(const std::vector<uint8_t>& d
 	uint64_t data_little_endian = 0;
 	uint64_t data_big_endian = 0;
 	for (std::size_t i = 0; i < size; i++) {
-		data_little_endian |= ((uint64_t)data[i]) << i * ONE_BYTE;
 		data_big_endian = (data_big_endian << ONE_BYTE) | (uint64_t)data[i];
 	}
+	data_little_endian = ntohl(data_little_endian);
 
 	// TODO: does this also work on a big endian machine?
 
 	const auto len = size * 8;
 	uint64_t value = 0;
 	for (const auto& signal : m_signals) {
+
+		if (signal.size > len) {
+			return ParseSignalsStatus::ErrorInvalidSignalSize;
+		}
+
 		if (signal.is_bigendian) {
 			uint32_t start_bit = ONE_BYTE * (signal.start_bit / ONE_BYTE) + (SEVEN_BITS - (signal.start_bit % ONE_BYTE)); // Calculation taken from python CAN
 			value = data_big_endian << start_bit;

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -92,7 +92,7 @@ void Message::append_signal(const Signal& signal) {
 	m_signals.push_back(signal);
 }
 
-std::vector<Signal> Message::get_signals() const {
+const std::vector<Signal>& Message::get_signals() const {
 	return m_signals;
 }
 

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 namespace Libdbc {
-Signal::Signal(std::string name,
+Signal::Signal(const std::string& name,
 			   bool is_multiplexed,
 			   uint32_t start_bit,
 			   uint32_t size,
@@ -15,8 +15,8 @@ Signal::Signal(std::string name,
 			   double offset,
 			   double min,
 			   double max,
-			   std::string unit,
-			   std::vector<std::string> receivers)
+			   const std::string& unit,
+			   const std::vector<std::string>& receivers)
 	: name(name)
 	, is_multiplexed(is_multiplexed)
 	, start_bit(start_bit)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -65,13 +65,6 @@ std::istream& StreamHandler::skip_to_next_blank_line(std::istream& stream, std::
 	return stream;
 }
 
-std::string String::trim(const std::string& line) {
-	const char* WhiteSpace = " \t\v\r\n";
-	std::size_t start = line.find_first_not_of(WhiteSpace);
-	std::size_t end = line.find_last_not_of(WhiteSpace);
-	return start == end ? std::string() : line.substr(start, end - start + 1);
-}
-
 double String::convert_to_double(const std::string& value, double default_value) {
 	double converted_value = default_value;
 	// NOLINTNEXTLINE -- Trying to iterators on the value causes the test to infinitly hang on windows builds

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -8,21 +8,11 @@
 namespace Utils {
 
 std::istream& StreamHandler::get_line(std::istream& stream, std::string& line) {
-	std::string newline;
-
-	std::getline(stream, newline);
-
-	// Windows CRLF (\r\n)
-	if (!newline.empty() && newline[newline.size() - 1] == '\r') {
-		line = newline.substr(0, newline.size() - 1);
-		// MacOS LF (\r)
-	} else if (!newline.empty() && newline[newline.size()] == '\r') {
-		line = newline.replace(newline.size(), 1, "\n");
-	} else {
-		line = newline;
-	}
-
-	return stream;
+	std::getline(stream, line);
+    if (!line.empty() && line.back() == '\r') {
+        line.pop_back(); // strip CR from CRLF
+    }
+    return stream;
 }
 
 std::istream& StreamHandler::get_next_non_blank_line(std::istream& stream, std::string& line) {

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -41,7 +41,8 @@ maybe not this one either\n\
 \n\
 Someone wrote something....\n\
    b\n\
-end";
+end\
+";
 
 	std::istringstream stream(test_string);
 

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -78,7 +78,7 @@ end";
 TEST_CASE("Test the string trim feature", "[string]") {
 	std::string s = "    	there might be some white space....   ";
 
-	REQUIRE(String::trim(s) == "there might be some white space....");
+	REQUIRE(trim(s) == "there might be some white space....");
 }
 
 TEST_CASE("Test string split feature", "[string]") {


### PR DESCRIPTION
### Added
- Adds `isWhitespaceOrEmpty` template function.
- Adds support for concepts if enabled and supported by the compiler.

### Changed
- Replaces `String::trim` function with generic trim template functions which work with modern C++ types, such as `string_view`.

### Removed
- Removes `String::trim` function, in favor of generic trim template functions.

### Fixed
- Fixes broken logic in `get_line` function.
- Fixes broken const-correctness in `dbc.hpp` and `dbc.cpp`.
- Fixes logic error in unit test.
- Fixes weird logic in `get_next_non_blank_line` and `skip_to_next_blank_line` by replacing an expensive regex with simpler and faster char checks.